### PR TITLE
Update Readme to fix URL typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud Domains
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-domains.svg
    :target: https://pypi.org/project/google-cloud-domains/
 .. _Cloud Domains: https://cloud.google.com/domains
-.. _Client Library Documentation: https://googleapis.dev/python/domainslatest
+.. _Client Library Documentation: https://googleapis.dev/python/domains/latest
 .. _Product Documentation:  https://cloud.google.com/domains
 
 Quick Start


### PR DESCRIPTION
URL to Client Library Documentation had a typo that broke the link.

Fixes #91 🦕
